### PR TITLE
Added support for older ProcessWire versions

### DIFF
--- a/InputfieldFontIconPicker.module
+++ b/InputfieldFontIconPicker.module
@@ -130,7 +130,13 @@ class InputfieldFontIconPicker extends Inputfield {
 			file_exists($this->iconsPath . $this->fontLibrary . ".php"))
 		{
 			if(!function_exists('InputfieldFontIconPicker' . $this->fontLibrary)) {
-                wire('files')->include($this->iconsPath . $this->fontLibrary);
+				$files = wire('files');
+				if( $files ) {
+					$files->include($this->iconsPath . $this->fontLibrary);
+				}
+				else {
+					include($this->iconsPath . $this->fontLibrary.'.php');
+				}
 			}
 
 			return array(


### PR DESCRIPTION
Old ProcessWire (2.x) do not have wire('files').

We noticed this in a site running 2.7.2.